### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTE:** This repo is currently out of date. An updated version is at https://github.com/KDE/homebrew-kde
+
 homebrew-kf5
 ============
 


### PR DESCRIPTION
Add note pointing to maintained version of repo. Google gave this repo as the first result for "Building KDE on MacOS", so would be good to point people to the maintained version.